### PR TITLE
limit glearn config file to user only to protect API key

### DIFF
--- a/app/cmd/root.go
+++ b/app/cmd/root.go
@@ -104,7 +104,7 @@ func init() {
 			initialConfig := []byte(`api_token:`)
 
 			// Write a ~/.glearn-config.yaml file with all the needed credential keys to fill in.
-			err = ioutil.WriteFile(configPath, initialConfig, 0666)
+			err = ioutil.WriteFile(configPath, initialConfig, 0600)
 			if err != nil {
 				fmt.Println("Error writing your glearn config file")
 				os.Exit(1)


### PR DESCRIPTION
Similar to the policy for the `.ssh/authorized_keys` file, setting the permissions for the config file to only allow the user to access it adds another layer of protection for the API key.