### PR TITLE
Add open browser on Windows for preview

### DIFF
--- a/app/cmd/command.go
+++ b/app/cmd/command.go
@@ -1,0 +1,39 @@
+// Package command provides wrappers around bash commands in order to support
+// commands across multiple operating systems. The commands in this script
+// should detect if a feature is supported, and if it is, use the feature that
+// is best suited for the platform.
+package cmd
+
+import (
+	"os/exec"
+	"fmt"
+)
+
+// isCommandAvailable checks to see if a command is available.
+// It returns true if the command is available, false otherwise
+func isCommandAvailable(command string) bool {
+	result := exec.Command("bash", "-c", fmt.Sprintf("command -v %s", command))
+	if err := result.Run(); err != nil {
+		return false
+	}
+	return true
+}
+
+// openURL attempts to open the specified URL in a new browser window.
+// It checks to see if the open command is supported first, and if not, the
+// start command. If either of the commands is supported, the appropriate
+// command will be executed. If neither one is supported, a browser window will
+// not be opened. No message is returned.
+func openURL(url string) {
+	var openBrowserCommand string
+
+	if isCommandAvailable("open") {
+		openBrowserCommand = "open"
+	} else if isCommandAvailable("start") {
+		openBrowserCommand = "start"
+	}
+
+	if len(openBrowserCommand) > 0 {
+		exec.Command("bash", "-c", fmt.Sprintf("%s %s", openBrowserCommand, url)).Output()
+	}
+}

--- a/app/cmd/preview.go
+++ b/app/cmd/preview.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -234,7 +233,7 @@ preview and return/open the preview URL when it is complete.
 		printlnGreen("√")
 
 		if OpenPreview {
-			exec.Command("bash", "-c", fmt.Sprintf("open %s", res.PreviewURL)).Output()
+			openURL(res.PreviewURL)
 		}
 
 		err = learn.API.SendMetadataToLearn(&learn.CLIBenchmarkPayload{


### PR DESCRIPTION
**Why was this change made?**

The browser does not open when executing the `-o` flag when running the
`preview` command on Windows.

**What functionality was changed?**

In order to support this need, the following changes have been made:
- Add a file called `command.go`.
- Modify `preview.go` to use the openURL command in the `command.go` file.

**What are the side effects of the change outside of this repository?**

This has not yet been validated on Mac OS or Linux distributions.
Additional testing should be performed on these platforms before merging
into master.