### PR TITLE
Add a CI/CD flag to prevent pushing changes.

### DIFF
--- a/app/cmd/publish.go
+++ b/app/cmd/publish.go
@@ -93,7 +93,11 @@ new block. If the block already exists, it will update the existing block.
 		}
 		fmt.Printf("Publishing block with repo name %s from branch %s\n", repoPieces.RepoName, branch)
 
-		if createdConfig {
+		if createdConfig && CiCdEnvironment {
+			fmt.Println("\nError: You cannot use autoconfig.yaml from a CI/CD environment.")
+			fmt.Println("Please create a config.yaml file and commit it.")
+			os.Exit(1)
+		} else if createdConfig {
 			fmt.Println("Committing autoconfig.yaml to", branch)
 			err = addAutoConfigAndCommit()
 
@@ -103,12 +107,15 @@ new block. If the block already exists, it will update the existing block.
 			}
 		}
 
-		fmt.Println("Pushing work to remote origin", branch)
+		// Do not push if in a CI/CD environment
+		if !CiCdEnvironment {
+			fmt.Println("Pushing work to remote origin", branch)
 
-		err = pushToRemote(branch)
-		if err != nil {
-			fmt.Printf("\nError pushing to origin remote on branch:\n\n%s", err)
-			os.Exit(1)
+			err = pushToRemote(branch)
+			if err != nil {
+				fmt.Printf("\nError pushing to origin remote on branch:\n\n%s", err)
+				os.Exit(1)
+			}
 		}
 
 		// Start benchmark for creating master release & building on learn

--- a/app/cmd/root.go
+++ b/app/cmd/root.go
@@ -68,6 +68,9 @@ var OpenPreview bool
 // Ignore local changes and publish remote only
 var IgnoreLocal bool
 
+// Running in a CI environment and should not try to push changes
+var CiCdEnvironment bool
+
 func init() {
 	u, err := user.Current()
 	if err != nil {
@@ -115,6 +118,7 @@ func init() {
 	previewCmd.Flags().BoolVarP(&FileOnly, "fileonly", "x", false, "Excludes images when previewing a single file, defaults false")
 	publishCmd.Flags().StringVarP(&UnitsDirectory, "units", "u", "", "The directory where your units exist")
 	publishCmd.Flags().BoolVarP(&IgnoreLocal, "ignore-local", "", false, "Ignore local changes and publish remote only")
+	publishCmd.Flags().BoolVarP(&CiCdEnvironment, "ci-cd", "", false, "Running in a CI/CD environment (cannot use with autoconfig feature)")
 	markdownCmd.Flags().BoolVarP(&PrintTemplate, "out", "o", false, "Prints the template to stdout")
 	markdownCmd.Flags().BoolVarP(&Minimal, "min", "m", false, "Uses a terse, minimal version of the template")
 }


### PR DESCRIPTION
In a CI/CD environment, there are no changes that must be
pushed because CI/CD has the most recent environment. This
flag prevents the push from happening.

Note: the --ci-cd flag cannot be used with the autoconfig
feature because that would require a push.