### PR TITLE
Uses regex to match repos instead of "/" separator

### DIFF
--- a/app/cmd/publish.go
+++ b/app/cmd/publish.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"regexp"
+
 	"github.com/briandowns/spinner"
 	"github.com/gSchool/glearn-cli/api/learn"
 	"github.com/spf13/cobra"
@@ -199,34 +201,27 @@ func currentBranch() (string, error) {
 	return runBashCommand(branchCommand)
 }
 
+var hostedGitRe = regexp.MustCompile(`^(:?(\w+):\/\/\/?)?(?:(~?\w+)@)?([\w\d\.\-_]+)(:?:([\d]+))?(?::)?\/*(.*)\/([\w\d\.\-_]+)(?:\.git)\/?$`)
+
+func parseHostedGitRegex(originUrl string) (repoParts learn.RepoPieces, err error) {
+	var repoPieces learn.RepoPieces
+	if m := hostedGitRe.FindStringSubmatch(originUrl); m != nil {
+		repoPieces, err = learn.RepoPieces{
+			Origin: m[4],
+			Org: m[7],
+			RepoName: m[8],
+		}, nil
+	}
+	return repoPieces, err
+}
+
 func remotePieces() (learn.RepoPieces, error) {
 	var repoPieces learn.RepoPieces
 	s, err := runBashCommand(pushRemoteCommand)
 	if err != nil {
 		return repoPieces, err
 	}
-	parts := strings.Split(s, ".git")
-	if len(parts) < 1 { // There should only be 1
-		return repoPieces, fmt.Errorf("Error parsing git remote from %s", s)
-	}
-	parts = strings.Split(parts[0], "/")
-
-	// does it start with https
-	if parts[0] == "https:" || parts[0] == "ssh:" {
-		repoPieces.Origin = strings.ReplaceAll(parts[2], "git@", "")
-		repoPieces.Org = parts[3]
-		repoPieces.RepoName = parts[4]
-
-		return repoPieces, nil
-	}
-
-	repoPieces.RepoName = parts[1]
-	parts = strings.Split(parts[0], ":")
-	repoPieces.Org = parts[1]
-	parts = strings.Split(parts[0], "@")
-	repoPieces.Origin = parts[1]
-
-	return repoPieces, nil
+	return parseHostedGitRegex(s)
 }
 
 func pushToRemote(branch string) error {

--- a/app/cmd/publish_test.go
+++ b/app/cmd/publish_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func Test_parseHostedGitRegex_many(t *testing.T) {
+	var origins = []string{
+		"git@gitlab.com:gsei19/nineteen-week/week-02-full-stack-by-feature.git",
+		"https://gitlab.com/gsei19/week-05.git",
+		"git@github.com:golang/from/go.git",
+		"ssh://user@host.xz/path/to/repo.git/",
+		"ssh://user@host-website.xz:1234/path-path/to-to/repo-repo.git/",
+		"ssh://host.xz:7634/path/to/repo-name-nam.git/",
+		"ssh://host.xz/path/to/repo-name.git/",
+		"ssh://user@host.xz/path/to/repo-name.git/",
+		"ssh://host.xz/path/to/repo-name.git/",
+		"user@host.xz:/path/to/repo.git/",
+		"host.xz:/path/to/repo-name.git/",
+		"user@host.xz:path/to/repo.git",
+		"host.xz:path/to/repo.git",
+		"rsync://host.xz/path/to/repo.git/",
+		"git://host.xz/path/to/repo.git/",
+		"http://host.xz/path/to/repo.git/",
+		"https://host.xz/path/to/repo.git/",
+	}
+	for _, origin := range origins {
+		var repoPieces, _ = parseHostedGitRegex(origin)
+		if repoPieces.Org == "" {
+			t.Errorf("Org parse failed")
+		}
+	}
+}
+
+func Test_parseRepoPieces_TopLevelOrg(t *testing.T) {
+	repoPieces, err := parseHostedGitRegex("https://gitlab.com/gsei19/week-05.git")
+
+	if err != nil {
+		t.Errorf("Threw an error")
+	}
+
+	// https://gitlab.com/gsei19/nineteen-week/week-05.git
+
+	if repoPieces.Org != "gsei19" {
+		t.Errorf("Incorrect org parse")
+	}
+}
+
+func Test_parseRepoPieces_TopLevelOrg_Ssh(t *testing.T) {
+	repoPieces, err := parseHostedGitRegex("git@github.com:golang/go.git")
+
+	if err != nil {
+		t.Errorf("Threw an error")
+	}
+
+	// https://gitlab.com/gsei19/nineteen-week/week-05.git
+
+	if repoPieces.Origin != "github.com" {
+		t.Errorf("Incorrect Origin parse")
+	}
+
+	if repoPieces.RepoName != "go" {
+		t.Errorf("Incorrect RepoName parse")
+	}
+
+	if repoPieces.Org != "golang" {
+		t.Errorf("Incorrect org parse")
+	}
+}
+
+func Test_parseRepoPieces_NestedOrg(t *testing.T) {
+	repoPieces, err := parseHostedGitRegex("https://gitlab.com/gsei19/nineteen-week/week-05.git")
+
+	if err != nil {
+		t.Errorf("Threw an error")
+	}
+
+	// https://gitlab.com/gsei19/nineteen-week/week-05.git
+
+	if repoPieces.Org != "gsei19/nineteen-week" {
+		t.Errorf("Incorrect org parse")
+	}
+}


### PR DESCRIPTION
Regex seems to be the method Go has used internally for checking url-like patterns like this. I also found Github and Gitlab implementations of such.

This regex is pretty robust and should work for any gitlab or github implementation of a repo and a little beyond.

Below is an image of a visual demo:

![image](https://user-images.githubusercontent.com/23508546/157339897-b05361fe-4f0e-4bc1-9e3a-88c380a39853.png)
