### PR TITLE
Update version check to use semantic versioning.

### DIFF
--- a/app/cmd/root.go
+++ b/app/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"os/user"
 	"time"
 
+	"github.com/Masterminds/semver"
 	"github.com/gSchool/glearn-cli/api/github"
 	"github.com/gSchool/glearn-cli/api/learn"
 	"github.com/spf13/cobra"
@@ -153,7 +154,17 @@ func setupLearnAPI(getPresignedPostUrl bool) {
 	if err != nil {
 		fmt.Printf("Something went wrong when fetching latest CLI version: %s\n", err)
 	} else if version != currentReleaseVersion {
-		fmt.Printf("\nWARNING: There is newer version of the learn tool available.\nLatest: %s\nCurrent: %s\nTo avoid issues, upgrade by following the instructions at this link:\nhttps://github.com/gSchool/glearn-cli/blob/master/upgrade_instructions.md\n\n", version, currentReleaseVersion)
+		versionRemote, versionRemoteErr := semver.NewVersion(version)
+		versionInstalled, versionInstalledErr := semver.NewVersion(currentReleaseVersion)
+		if versionRemoteErr != nil {
+			fmt.Printf("Failed to parse the CLI's current version. Err: %v", err)
+		}
+		if versionInstalledErr != nil {
+			fmt.Printf("Failed to parse the latest CLI release version. Err: %v", err)
+		}
+		if versionInstalled.LessThan(versionRemote) {
+			fmt.Printf("\nWARNING: There is newer version of the learn tool available.\nLatest: %s\nCurrent: %s\nTo avoid issues, upgrade by following the instructions at this link:\nhttps://github.com/gSchool/glearn-cli/blob/master/upgrade_instructions.md\n\n", version, currentReleaseVersion)
+		}
 	}
 
 	learn.API = api

--- a/app/cmd/root.go
+++ b/app/cmd/root.go
@@ -158,11 +158,9 @@ func setupLearnAPI(getPresignedPostUrl bool) {
 		versionInstalled, versionInstalledErr := semver.NewVersion(currentReleaseVersion)
 		if versionRemoteErr != nil {
 			fmt.Printf("Failed to parse the CLI's current version. Err: %v", err)
-		}
-		if versionInstalledErr != nil {
+		} else if versionInstalledErr != nil {
 			fmt.Printf("Failed to parse the latest CLI release version. Err: %v", err)
-		}
-		if versionInstalled.LessThan(versionRemote) {
+		} else if versionInstalled.LessThan(versionRemote) {
 			fmt.Printf("\nWARNING: There is newer version of the learn tool available.\nLatest: %s\nCurrent: %s\nTo avoid issues, upgrade by following the instructions at this link:\nhttps://github.com/gSchool/glearn-cli/blob/master/upgrade_instructions.md\n\n", version, currentReleaseVersion)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/VividCortex/ewma v1.1.1 // indirect
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=


### PR DESCRIPTION
Closes #124.

This change adds a new dependency to

    github.com/Masterminds/semver

It now parses the published version from GitHub and the installed version, then does a comparison of the two versions using the semantic versioning algorithm.

@pgrunde @ToriK17 Tagging for visibility.