### PR TITLE
Print fatal messages to standard error.

### DIFF
--- a/app/cmd/guide.go
+++ b/app/cmd/guide.go
@@ -69,19 +69,19 @@ var guideCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		currentDir, err := os.Getwd()
 		if err != nil {
-			fmt.Println("Could not detect a working directory")
+			fmt.Fprintln(os.Stderr, "Could not detect a working directory")
 			os.Exit(1)
 		}
 
 		// Does that directory have a config file
 		hasConfig, _ := doesCurrentDirHaveConfig(currentDir)
 		if hasConfig {
-			fmt.Println("WARNING: configuration file detected and cannot continue with `learn walkthrough` command.")
+			fmt.Fprintln(os.Stderr, "WARNING: configuration file detected and cannot continue with `learn walkthrough` command.")
 			os.Exit(1)
 		}
 		_, dirExists := os.Stat("/" + guideDir)
 		if dirExists == nil {
-			fmt.Printf("A directory already exists by the name '%s', rename or move it.\n", guideDir)
+			fmt.Fprintf(os.Stderr, "A directory already exists by the name '%s', rename or move it.\n", guideDir)
 			os.Exit(1)
 		}
 
@@ -90,7 +90,7 @@ var guideCmd = &cobra.Command{
 		// Create contents in the directory
 		err = generateGuide(currentDir)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 

--- a/app/cmd/markdown.go
+++ b/app/cmd/markdown.go
@@ -29,7 +29,7 @@ var markdownCmd = &cobra.Command{
 		if len(args) == 1 {
 			t, err := getTemp(args[0])
 			if err != nil {
-				fmt.Println(err)
+				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
 			if PrintTemplate {
@@ -41,19 +41,19 @@ var markdownCmd = &cobra.Command{
 		} else if len(args) == 2 {
 			t, err := getTemp(args[0])
 			if err != nil {
-				fmt.Println(err)
+				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
 			if PrintTemplate {
 				fmt.Println("-o flag skipped when appending...")
 			}
 			if err = t.appendContent(args[1]); err != nil {
-				fmt.Println(err)
+				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
 
 		} else {
-			fmt.Println(incorrectNumArgs)
+			fmt.Fprintln(os.Stderr, incorrectNumArgs)
 			os.Exit(1)
 		}
 

--- a/app/cmd/preview.go
+++ b/app/cmd/preview.go
@@ -582,7 +582,7 @@ func copyDockerPaths(target string, dockerPaths []string) (err error) {
 				// the directory was found after checking parents, copy contents
 				ignorePatterns, err := DockerIgnorePatterns(newDirPath)
 				if err != nil {
-					fmt.Print(err.Error())
+					fmt.Fprint(os.Stderr, err.Error())
 				}
 
 				err = CopyDirectoryContents(newDirPath, tmpSingleFileDir+"/"+dirPath, ignorePatterns)
@@ -596,7 +596,7 @@ func copyDockerPaths(target string, dockerPaths []string) (err error) {
 		} else {
 			ignorePatterns, err := DockerIgnorePatterns(dirPath)
 			if err != nil {
-				fmt.Print(err.Error())
+				fmt.Fprint(os.Stderr, err.Error())
 			}
 
 			err = CopyDirectoryContents(dirPath, tmpSingleFileDir+"/"+dirPath, ignorePatterns)
@@ -675,7 +675,7 @@ func createLinkDirectories(pathArray []string) (linkDirs string, err error) {
 // previewCmdError is a small wrapper for all errors within the preview command. It ensures
 // artifacts are cleaned up with a call to removeArtifacts
 func previewCmdError(msg, tmpZipFile string) {
-	fmt.Println(msg)
+	fmt.Fprintln(os.Stderr, msg)
 	removeArtifacts(tmpZipFile)
 	learn.API.NotifySlack(errors.New(msg))
 	os.Exit(1)
@@ -778,14 +778,14 @@ func createChecksumFromZip(file *os.File) (string, error) {
 func removeArtifacts(tmpZipFile string) {
 	err := os.Remove(tmpZipFile)
 	if err != nil {
-		fmt.Println("Sorry, we had trouble cleaning up the zip file created for curriculum preview")
+		fmt.Fprintln(os.Stderr, "Sorry, we had trouble cleaning up the zip file created for curriculum preview")
 	}
 
 	// Remove tmpSingleFileDir if it exists at this point
 	if _, err := os.Stat(tmpSingleFileDir); !os.IsNotExist(err) {
 		err = os.RemoveAll(tmpSingleFileDir)
 		if err != nil {
-			fmt.Println("Sorry, we had trouble cleaning up the tmp single file preview directory")
+			fmt.Fprintln(os.Stderr, "Sorry, we had trouble cleaning up the tmp single file preview directory")
 		}
 	}
 }
@@ -865,7 +865,7 @@ func CopyDirectoryContents(src, dst string, ignorePatterns []string) error {
 			localizedPattern := src + "/" + pattern
 			matched, err := di.IgnoreMatches(localizedPattern, source)
 			if err != nil {
-				fmt.Printf("error while parsing at: %s", err)
+				fmt.Fprintf(os.Stderr, "error while parsing at: %s", err)
 			}
 			if matched {
 				ignore = matched

--- a/app/cmd/root.go
+++ b/app/cmd/root.go
@@ -73,7 +73,7 @@ var CiCdEnvironment bool
 func init() {
 	u, err := user.Current()
 	if err != nil {
-		fmt.Println("Error retrieving your user path information")
+		fmt.Fprintln(os.Stderr, "Error retrieving your user path information")
 		os.Exit(1)
 		return
 	}
@@ -90,13 +90,13 @@ func init() {
 			// Write a ~/.glearn-config.yaml file with all the needed credential keys to fill in.
 			err = ioutil.WriteFile(configPath, initialConfig, 0600)
 			if err != nil {
-				fmt.Println("Error writing your glearn config file")
+				fmt.Fprintln(os.Stderr, "Error writing your glearn config file")
 				os.Exit(1)
 				return
 			}
 		} else {
 			// Config file was found but another error was produced
-			fmt.Printf("Error: %s", err)
+			fmt.Fprintf(os.Stderr, "Error: %s", err)
 			os.Exit(1)
 			return
 		}
@@ -128,7 +128,7 @@ func init() {
 // Execute runs the learn CLI according to the user's command/subcommand/flags
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }
@@ -143,7 +143,7 @@ func setupLearnAPI(getPresignedPostUrl bool) {
 
 	api, err := learn.NewAPI(baseURL, &client, getPresignedPostUrl)
 	if err != nil {
-		fmt.Printf("Error creating API client. Err: %v", err)
+		fmt.Fprintf(os.Stderr, "Error creating API client. Err: %v", err)
 		os.Exit(1)
 		return
 	}

--- a/app/cmd/set.go
+++ b/app/cmd/set.go
@@ -18,13 +18,13 @@ credentials inside ~/.glearn-config.yaml
 	Args: cobra.MinimumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 0 {
-			fmt.Println("The set command does not take any arguments. Instead set variables with set --api_token=value")
+			fmt.Fprintln(os.Stderr, "The set command does not take any arguments. Instead set variables with set --api_token=value")
 			os.Exit(1)
 		}
 
 		// If the --api_token=some_value flag was given, set it in viper
 		if APIToken == "" {
-			fmt.Println("The set command needs '--api_token' flag.\n\nUse: learn set --api_token=value")
+			fmt.Fprintln(os.Stderr, "The set command needs '--api_token' flag.\n\nUse: learn set --api_token=value")
 			os.Exit(1)
 		} else {
 			viper.Set("api_token", APIToken)
@@ -33,7 +33,7 @@ credentials inside ~/.glearn-config.yaml
 		// Write any changes made above to the config
 		err := viper.WriteConfig()
 		if err != nil {
-			fmt.Printf("There was an error writing credentials to your config: %v", err)
+			fmt.Fprintf(os.Stderr, "There was an error writing credentials to your config: %v", err)
 			os.Exit(1)
 			return
 		}

--- a/app/cmd/version.go
+++ b/app/cmd/version.go
@@ -14,7 +14,7 @@ var versionCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 0 {
-			fmt.Println("The version command does not take any arguments")
+			fmt.Fprintln(os.Stderr, "The version command does not take any arguments")
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
Closes #126 

Everywhere there is a direct or indirect call to `os.Exit`, this pull request changes the corresponding `fmt.P*(...)` method to the comparable `fmt.Fp*(os.Stderr, ...)` version.

@pgrunde @ToriK17 Tagging you for visibility.