### PR TITLE
Honor .gitignore entries in autoconfig.yaml generation and preview

### DIFF
--- a/app/cmd/preview_test.go
+++ b/app/cmd/preview_test.go
@@ -11,6 +11,10 @@ import (
 	"testing"
 )
 
+const ignoredMDContent = `## Ignored
+
+This file should be ignored.`
+
 const testMDContent = `## Test links
 
 ![alt](./image/nested-small.png)
@@ -59,6 +63,21 @@ func Test_compressDirectory(t *testing.T) {
 		t.Errorf("There should be paths parsed from the target")
 	}
 
+	err = createTestFile("../../fixtures/test-block-auto-config/ignored.md", ignoredMDContent)
+	if err != nil {
+		t.Error("Could not make ignored.md")
+	}
+
+	err = os.MkdirAll("../../fixtures/test-block-auto-config/ignored/", os.FileMode(0777))
+	if err != nil {
+		t.Error("Could not make ignored/")
+	}
+
+	err = createTestFile("../../fixtures/test-block-auto-config/ignored/ignored.md", ignoredMDContent)
+	if err != nil {
+		t.Error("Could not make ignored/ignored.md")
+	}
+
 	tmpZipFile := "../../fixtures/test-block-auto-config/preview-curriculum.zip"
 
 	var challengePaths []string
@@ -105,6 +124,16 @@ func Test_compressDirectory(t *testing.T) {
 		if found == false {
 			t.Errorf("Should of found: %s In zipped dir", path)
 		}
+	}
+
+	fmt.Printf("%+v", paths)
+
+	if _, ok := paths["ignored.md"]; ok {
+		t.Error("ZIP should not contain ignored.md")
+	}
+
+	if _, ok := paths["ignored/ignored.md"]; ok {
+		t.Error("ZIP should not contain ignored/ignored.md")
 	}
 
 	os.Remove(tmpZipFile)
@@ -551,7 +580,11 @@ func testFilesExist(t *testing.T, paths []string) {
 }
 
 func createTestMD(content string) error {
-	f, err := os.OpenFile("test.md", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	return createTestFile("test.md", content)
+}
+
+func createTestFile(fileName string, content string) error {
+	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}

--- a/fixtures/test-block-auto-config/.gitignore
+++ b/fixtures/test-block-auto-config/.gitignore
@@ -1,0 +1,2 @@
+ignored.md
+ignored/

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,8 @@ require (
 
 require (
 	github.com/VividCortex/ewma v1.1.1 // indirect
+	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect
+	github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817 // indirect
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,12 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5EPKqaS1UYVg1uYah5Xf51mBfIoWehClUQ=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964/go.mod h1:Xd9hchkHSWYkEqJwUGisez3G1QY8Ryz0sdWrLPMGjLk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817 h1:0nsrg//Dc7xC74H/TZ5sYR8uk4UQRNjsw8zejqH5a4Q=
+github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817/go.mod h1:C/+sI4IFnEpCn6VQ3GIPEp+FrQnQw+YQP3+n+GdGq7o=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=


### PR DESCRIPTION
This commit uses the go-gitignore library to parse a .gitignore file in the target directory should it exist. It then prevents files from being added to the autoconfig.yaml and, in the case of preview, the ZIP file that contains the contents of the repo.

## Tests

Added checks to the `Test_compressDirectory` test to confirm that ignored directories and files are not included in the ZIP`