### PR TITLE
bug: external pdf shouldn't check for local file

### DIFF
--- a/app/cmd/guide.go
+++ b/app/cmd/guide.go
@@ -135,7 +135,7 @@ func generateGuide(currentDir string) error {
 		{"README.md", readme},
 		{"01-example-unit/00-hello-world.md", helloWorldMd},
 		{"01-example-unit/01-configuration.md", configurationMd},
-		{"01-example-unit/02-publishng.md", publishingMd},
+		{"01-example-unit/02-publishing.md", publishingMd},
 		{"01-example-unit/03-markdown-examples.md", markdownExamplesMd},
 		{"01-example-unit/04-challenges.md", challengesMd},
 		{"01-example-unit/05-checkpoint.md", checkpointMd},

--- a/app/cmd/preview.go
+++ b/app/cmd/preview.go
@@ -911,6 +911,9 @@ func (p *previewBuilder) parseConfigAndGatherPaths() error {
 
 	for _, std := range config.Standards {
 		for _, cf := range std.ContentFiles {
+			if strings.ToLower(cf.Type) == "external" {
+				continue
+			}
 			contents, err := ioutil.ReadFile(p.target + cf.Path)
 			if err != nil {
 				return fmt.Errorf("Failure to read file '%s'. Err: %s", string(contents), err)

--- a/app/cmd/preview_test.go
+++ b/app/cmd/preview_test.go
@@ -542,6 +542,33 @@ func Test_createNewTarget_DockerDirectoryDoubleNestedMd(t *testing.T) {
 	}
 }
 
+func Test_ParseConfigFileSkipsExternalType(t *testing.T) {
+	source := "../../fixtures/test-block-with-external"
+	p := previewBuilder{target: source}
+	err := p.parseConfigAndGatherPaths()
+	if err != nil {
+		t.Errorf("parseConfigAndGatherPaths should not error when external content files are present: %s", err)
+	}
+
+	// The external content file should not be in configYamlPaths
+	for _, path := range p.configYamlPaths {
+		if strings.Contains(path, "external-link") {
+			t.Errorf("configYamlPaths should not contain external content file path, but found: %s", path)
+		}
+	}
+
+	// The lesson file should still be present
+	foundLesson := false
+	for _, path := range p.configYamlPaths {
+		if strings.Contains(path, "lesson.md") {
+			foundLesson = true
+		}
+	}
+	if !foundLesson {
+		t.Errorf("configYamlPaths should contain the lesson content file path")
+	}
+}
+
 func testFilesExist(t *testing.T, paths []string) {
 	for _, file := range paths {
 		if _, err := os.Stat(fmt.Sprintf("single-file-upload/%s", file)); os.IsNotExist(err) {

--- a/fixtures/test-block-with-external/config.yaml
+++ b/fixtures/test-block-with-external/config.yaml
@@ -1,0 +1,13 @@
+Standards:
+  - Title: Unit with External
+    UID: abc123
+    Description: A unit with an external content file
+    SuccessCriteria:
+      - success criteria
+    ContentFiles:
+      - Type: Lesson
+        Path: /units/lesson.md
+        UID: def456
+      - Type: External
+        Path: https://gitlab.galvanize.com/galvanize-it/sandboxes/grunde/test-repo/-/blob/main/sample-report.pdf
+        UID: ghi789

--- a/fixtures/test-block-with-external/units/lesson.md
+++ b/fixtures/test-block-with-external/units/lesson.md
@@ -1,0 +1,3 @@
+# A Lesson
+
+This is a lesson.


### PR DESCRIPTION
The External file type was breaking on preview as it attempted to find the file locally. This fixes the issue and allows the file to be previewed as it is loaded from Gitlab.