### PR TITLE
ignore .claude dir

### DIFF
--- a/app/cmd/preview.go
+++ b/app/cmd/preview.go
@@ -169,6 +169,12 @@ func (p *previewBuilder) compressDirectory(zipTarget string) error {
 	filepath.Walk(p.target, func(path string, info os.FileInfo, err error) error {
 		path = filepath.ToSlash(path)
 
+		// Skip the .claude directory and all of its contents entirely so it is
+		// never collected into the preview payload.
+		if info != nil && info.IsDir() && filepath.Base(path) == ".claude" {
+			return filepath.SkipDir
+		}
+
 		fileIsIncluded := false
 		for _, p := range p.configYamlPaths {
 			var configPathSplits = strings.Split(p, string(os.PathSeparator))

--- a/app/cmd/preview_test.go
+++ b/app/cmd/preview_test.go
@@ -107,6 +107,13 @@ func Test_compressDirectory(t *testing.T) {
 		}
 	}
 
+	// The .claude directory and its contents should never be included in the payload.
+	for path := range paths {
+		if strings.Contains(path, ".claude/") {
+			t.Errorf("Should not have included file from .claude directory: %s", path)
+		}
+	}
+
 	os.Remove(tmpZipFile)
 }
 

--- a/fixtures/test-block-auto-config/.claude/notes.md
+++ b/fixtures/test-block-auto-config/.claude/notes.md
@@ -1,0 +1,4 @@
+# Claude Notes
+
+This markdown file lives inside a `.claude` directory and must never be
+included in the preview payload that is zipped and shipped to Learn.


### PR DESCRIPTION
Previewing projects with autoconfig and a .claude directory was causing issues with preview trying to pick up those markdown files.